### PR TITLE
Fixed: Cannot locate rosdep definition for [rocpp]

### DIFF
--- a/leaf_controller/CMakeLists.txt
+++ b/leaf_controller/CMakeLists.txt
@@ -8,7 +8,7 @@ project(leaf_controller)
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
-  rocpp
+  roscpp
   rospy
   std_msgs
 )
@@ -105,7 +105,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES leaf_controller
-#  CATKIN_DEPENDS rocpp rospy std_msgs
+#  CATKIN_DEPENDS roscpp rospy std_msgs
 #  DEPENDS system_lib
 )
 

--- a/leaf_controller/package.xml
+++ b/leaf_controller/package.xml
@@ -49,13 +49,13 @@
   <!-- Use doc_depend for packages you need only for building documentation: -->
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
-  <build_depend>rocpp</build_depend>
+  <build_depend>roscpp</build_depend>
   <build_depend>rospy</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_export_depend>rocpp</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
-  <exec_depend>rocpp</exec_depend>
+  <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 


### PR DESCRIPTION
roscpp was misspelled in package.xml and cmakelist files